### PR TITLE
Do not send transaction if new head is <= current head.

### DIFF
--- a/script/bin/operator.rs
+++ b/script/bin/operator.rs
@@ -194,7 +194,7 @@ impl SP1AvailLightClientOperator {
             let new_slot: u64 = proof_outputs.newHead.to();
             if new_slot <= head {
                 tracing::warn!(
-                    message = "New slot slot is <= from the current, skipping update",
+                    message = "New slot is <= from the current, skipping update",
                     current_slot = head,
                     new_slot = new_slot
                 );

--- a/script/bin/operator.rs
+++ b/script/bin/operator.rs
@@ -8,10 +8,10 @@ use helios_ethereum::consensus::Inner;
 use helios_ethereum::rpc::http_rpc::HttpRpc;
 use helios_ethereum::rpc::ConsensusRpc;
 
+use crate::SP1Helios::ProofOutputs;
 use alloy::sol_types::SolValue;
 use alloy_primitives::hex;
 use alloy_primitives::hex::ToHexExt;
-use avail_rust::avail::babe::storage::types::current_slot::CurrentSlot;
 use avail_rust::avail::runtime_types::bounded_collections::bounded_vec::BoundedVec;
 use avail_rust::avail_core::currency::AVAIL;
 use avail_rust::sp_core::{twox_128, Decode};
@@ -22,7 +22,7 @@ use jsonrpsee::{
     http_client::{HttpClient, HttpClientBuilder},
     rpc_params,
 };
-use sp1_helios_primitives::types::{ProofInputs, ProofOutputs};
+use sp1_helios_primitives::types::ProofInputs;
 use sp1_helios_script::*;
 use sp1_sdk::{
     NetworkProver, Prover, ProverClient, SP1ProofWithPublicValues, SP1ProvingKey, SP1Stdin,
@@ -191,7 +191,7 @@ impl SP1AvailLightClientOperator {
             let proof_outputs: ProofOutputs =
                 SolValue::abi_decode(&proof.public_values.as_slice(), true)
                     .context("Cannot decode public values")?;
-            let new_slot = proof_outputs.newHead.to();
+            let new_slot: u64 = proof_outputs.newHead.to();
             if new_slot <= head {
                 tracing::warn!(
                     message = "New slot slot is <= from the current, skipping update",

--- a/script/bin/operator.rs
+++ b/script/bin/operator.rs
@@ -189,7 +189,7 @@ impl SP1AvailLightClientOperator {
             info!("Generate proof end");
 
             let proof_outputs: ProofOutputs =
-                SolValue::abi_decode(&proof.public_values.as_slice(), true)
+                SolValue::abi_decode(proof.public_values.as_slice(), true)
                     .context("Cannot decode public values")?;
             let new_slot: u64 = proof_outputs.newHead.to();
             if new_slot <= head {

--- a/script/bin/operator.rs
+++ b/script/bin/operator.rs
@@ -8,8 +8,10 @@ use helios_ethereum::consensus::Inner;
 use helios_ethereum::rpc::http_rpc::HttpRpc;
 use helios_ethereum::rpc::ConsensusRpc;
 
+use alloy::sol_types::SolValue;
 use alloy_primitives::hex;
 use alloy_primitives::hex::ToHexExt;
+use avail_rust::avail::babe::storage::types::current_slot::CurrentSlot;
 use avail_rust::avail::runtime_types::bounded_collections::bounded_vec::BoundedVec;
 use avail_rust::avail_core::currency::AVAIL;
 use avail_rust::sp_core::{twox_128, Decode};
@@ -20,7 +22,7 @@ use jsonrpsee::{
     http_client::{HttpClient, HttpClientBuilder},
     rpc_params,
 };
-use sp1_helios_primitives::types::ProofInputs;
+use sp1_helios_primitives::types::{ProofInputs, ProofOutputs};
 use sp1_helios_script::*;
 use sp1_sdk::{
     NetworkProver, Prover, ProverClient, SP1ProofWithPublicValues, SP1ProvingKey, SP1Stdin,
@@ -185,6 +187,20 @@ impl SP1AvailLightClientOperator {
                 .timeout(Duration::from_secs(900))
                 .run()?;
             info!("Generate proof end");
+
+            let proof_outputs: ProofOutputs =
+                SolValue::abi_decode(&proof.public_values.as_slice(), true)
+                    .context("Cannot decode public values")?;
+            let new_slot = proof_outputs.newHead.to();
+            if new_slot <= head {
+                tracing::warn!(
+                    message = "New slot slot is <= from the current, skipping update",
+                    current_slot = head,
+                    new_slot = new_slot
+                );
+                return Ok(None);
+            }
+
             info!("Attempting to update to new head block: {:?}", latest_block);
             Ok(Some(proof))
         }


### PR DESCRIPTION
Do not send a transaction if the new slot is equal to or less than the current pallet slot. 