### PR TITLE
Filter stale/out-of-range updates from get_updates

### DIFF
--- a/script/bin/test.rs
+++ b/script/bin/test.rs
@@ -18,7 +18,7 @@ const ELF: &[u8] = include_bytes!("../../elf/sp1-helios-elf");
 async fn main() -> Result<()> {
     dotenv::dotenv().ok();
     setup_logger();
-    let slot = 10193088;
+    let slot = 10485824;
     // Test checkpoint slot
     let checkpoint = get_checkpoint(slot).await;
 

--- a/script/src/lib.rs
+++ b/script/src/lib.rs
@@ -26,13 +26,18 @@ pub async fn get_updates(
     let period =
         calc_sync_period::<MainnetConsensusSpec>(client.store.finalized_header.beacon().slot);
 
-    let updates = client
+    let mut updates = client
         .rpc
         .get_updates(period, MAX_REQUEST_LIGHT_CLIENT_UPDATES)
         .await
         .unwrap();
 
-    updates.clone()
+    updates.retain(|u| {
+        calc_sync_period::<MainnetConsensusSpec>(u.attested_header().beacon().slot) >= period
+    });
+    updates.sort_by_key(|u| u.attested_header().beacon().slot);
+
+    updates
 }
 
 /// Fetch latest checkpoint from chain to bootstrap client to the latest state.


### PR DESCRIPTION
Some beacon RPC providers return a malformed light_client/updates list when start_period is the current (in-progress) sync-committee period: they ignore `count`, prepend the head-period update, then dump their entire retained history (~200 older periods), out of order.

helios passes this through unsorted, so the SP1 program receives a stale update as entry #2 and verify_update rejects it with InvalidPeriod ("Update 2 is invalid!"), aborting the run.

Defend against the non-compliant response by keeping only updates whose sync period is >= the requested period and sorting ascending, so they form a clean chain starting from the store.